### PR TITLE
Discover latest version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,17 @@ geth_env_opts: []
 geth_discovery_public_ip: "true"
 # internal state to maintain idempotency
 geth_state_updates: []
+
+# Settig default value to None to validate the user input
+geth_version: ""
+geth_git_hash: ""
+
+# Internal variables which can be overridden but default to external variables
+_geth_version: "{{ geth_version}}"
+_geth_git_hash: "{{ geth_git_hash }}"
+
 # Version to install
-geth_download_url: "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-{{geth_version}}-{{geth_git_hash}}.tar.gz"
+geth_download_url: "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-{{ _geth_version }}-{{ _geth_git_hash }}.tar.gz"
 
 # Directory paths
 geth_base_dir: "/opt/geth"

--- a/tasks/cmdline.yml
+++ b/tasks/cmdline.yml
@@ -4,7 +4,7 @@
     geth_cmdline_args: >
       {{geth_cmdline_args}}
       --verbosity {{geth_log_verbosity}}
-      {{ geth_version is version_compare('1.11.6', '<') | ternary('--log.json', '--log.format ' + geth_log_format)}}
+      {{ _geth_version is version_compare('1.11.6', '<') | ternary('--log.json', '--log.format ' + geth_log_format)}}
       --datadir '{{geth_data_dir}}'
       --syncmode {{geth_sync_mode}}
       --port {{geth_p2p_port}}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -71,7 +71,7 @@
 
 - name: Create a symlink to current
   file:
-    src: "{{ geth_install_dir }}/geth-linux-amd64-{{geth_version}}-{{geth_git_hash}}"
+    src: "{{ geth_install_dir }}/geth-linux-amd64-{{ _geth_version}}-{{ _geth_git_hash }}"
     dest: "{{ geth_current_dir }}"
     state: link
   become: true

--- a/tasks/latest.yml
+++ b/tasks/latest.yml
@@ -1,0 +1,27 @@
+
+- name: Get latest geth tag
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/ethereum/go-ethereum/releases/latest
+    method: GET
+    status_code: 200
+  register: _geth_latest_tag
+
+- name: Set geth version
+  ansible.builtin.set_fact:
+    _geth_tag: "{{ _geth_latest_tag.json.tag_name }}"
+    _geth_version: "{{ _geth_latest_tag.json.tag_name | regex_replace('^v', '') }}"
+
+- name: Get tag commit hash
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/ethereum/go-ethereum/commits/{{ _geth_tag }}
+    method: GET
+    status_code: 200
+  register: _geth_latest_commit
+
+- name: Extract first 8 characters of commit hash
+  ansible.builtin.set_fact:
+    _geth_git_hash: "{{ _geth_latest_commit.json.sha[0:8] }}"
+
+- name: Information
+  debug:
+    msg: "Discovered geth_version [{{ _geth_version }}] and git_hash [{{ _geth_git_hash }}]"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+# Only checks whether both is not supplied. User can supply version as 'latest' and ignore
+- name: Verify geth version and git hash
+  fail:
+    msg: "Should supply geth_version and geth_git_hash parameter values"
+  when: geth_version == '' and geth_git_hash == ''
+
+- name: Include task latest
+  ansible.builtin.include_tasks: "latest.yml"
+  when: geth_version == 'latest'
+
+- name: Information
+  ansible.builtin.debug:
+    msg: "Installing geth [{{ _geth_version }}-{{ _geth_git_hash }}]"
+
 - name: Include OS and distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:
@@ -20,7 +34,7 @@
       when: ansible_os_family == "Darwin"
 
 - name: Install geth
-  include_tasks: "install.yml"
+  ansible.builtin.include_tasks: "install.yml"
 
 - name: Get IP address to bind to if not provided
   include_tasks: "network.yml"


### PR DESCRIPTION
Ansible role can discover the latest version when geth_version set to latest. Introduced _geth_version and _geth_git_hash internal variables as externally set variables cannot be override. Introduced parameter validation for geth_version and geth_git_hash